### PR TITLE
Redesign code to use configmap as the input

### DIFF
--- a/configure-nad/Dockerfile
+++ b/configure-nad/Dockerfile
@@ -7,4 +7,5 @@ COPY . .
 RUN go build -o /usr/local/bin/function ./
 FROM gcr.io/distroless/static:latest
 COPY --from=0 /usr/local/bin/function /usr/local/bin/function
+COPY cni-schemas/ /usr/local/bin/cni-schemas/
 ENTRYPOINT ["function"]

--- a/configure-nad/cni-schemas/macvlan.json
+++ b/configure-nad/cni-schemas/macvlan.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "master"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {"type": "string"},
+    "type": {"const": "macvlan"},
+    "master": {"type": "string"},
+    "mode": {"type": "string"},
+    "mtu": {"type": "number"},
+    "linkInContainer" : {"type":  "boolean"},
+    "ipam": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {"type": "string"}
+      }
+    }
+  }
+}

--- a/configure-nad/cni-schemas/sriov.json
+++ b/configure-nad/cni-schemas/sriov.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {"type": "string"},
+    "type": {"const": "sriov"},
+    "vlanProto": {"type": "string"},
+    "mac": {"type": "string"},
+    "spoofchk": {"type": "string"},
+    "trust": {"type": "string"},
+    "link_state": {"type": "string"},
+    "logLevel": {"type": "string"},
+    "logFile": {"type": "string"},
+    "vlan": {"type": "number"},
+    "vlanQoS": {"type": "number"},
+    "min_tx_rate": {"type": "number"},
+    "max_tx_rate": {"type": "number"},
+    "ipam": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {"type": "string"}
+      }
+    }
+  }
+}

--- a/configure-nad/go.mod
+++ b/configure-nad/go.mod
@@ -2,7 +2,10 @@ module main.go
 
 go 1.18
 
-require github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20230427202446-3255accc518d
+require (
+	github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20230427202446-3255accc518d
+	github.com/xeipuuv/gojsonschema v1.2.0
+)
 
 require (
 	github.com/GoogleContainerTools/kpt-functions-sdk/go/api v0.0.0-20220720212527-133180134b93 // indirect
@@ -23,6 +26,8 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/configure-nad/go.sum
+++ b/configure-nad/go.sum
@@ -300,6 +300,12 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=

--- a/configure-nad/main.go
+++ b/configure-nad/main.go
@@ -1,47 +1,229 @@
 package main
 
 import (
-	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+  	"path/filepath"
+	"strings"
 
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
+	"github.com/xeipuuv/gojsonschema"
 )
 
-var _ fn.Runner = &ConfigureNad{}
+var schemaValidators *schemaValidator
 
-type ConfigureNad struct {
-        Configs map[string]string
-} 
+type dataContainer interface {}
 
-func (cn *ConfigureNad) Run(ctx *fn.Context, functionConfig *fn.KubeObject, items fn.KubeObjects, results *fn.Results) bool {
-        if _, ok := cn.Configs["config"]; !ok {
-            *results = append(*results, fn.GeneralResult("config is missing!", fn.Error))
+type schemaValidator struct {
+	schemas map[string]*gojsonschema.Schema
+}
 
-            return false
+var defaultIdentifierAnnotation string = "configure-nad"
+
+func CreateNad(rl *fn.ResourceList) (bool, error) {
+        if err := InitSchemaValidator(filepath.Join(scriptDir(), "cni-schemas")); err != nil {
+               rl.Results = append(rl.Results, fn.ErrorResult(err))
+
+               return false, err
         }
 
-        for _, kubeObject := range items {
-            if kubeObject.IsGVK("k8s.cni.cncf.io", "v1", "NetworkAttachmentDefinition") {
-                if nadResource, ok := cn.Configs["resourceName"]; ok {
-                    kubeObject.SetAnnotation("k8s.v1.cni.cncf.io/resourceName", nadResource)
+        identifierAnnotation, exists, _ := rl.FunctionConfig.NestedString("data", "identifierAnnotation")
+        if !exists {
+            identifierAnnotation = defaultIdentifierAnnotation
+        }
+
+        resourceName, exists, _ := rl.FunctionConfig.NestedString("data", "resourceName")
+        if !exists {
+            resourceName = ""
+        }
+
+        for _, kubeObject := range rl.Items {
+                if !kubeObject.IsGVK("", "v1", "ConfigMap") {
+
+                        continue
                 }
 
-                if err := kubeObject.SetNestedString(cn.Configs["config"], "spec", "config"); err != nil {
-                    *results = append(*results, fn.ErrorResult(err))
-
-                    return false
+                if !kubeObject.HasAnnotations(map[string]string{identifierAnnotation: ""}){
+                        continue
                 }
-            }
-         }
 
-        *results = append(*results, fn.GeneralResult("Successfully configured NADs", fn.Info))
+                success, cniType, CNIConfigs, nadDir := loadConfigMapConfigs(kubeObject, &rl.Results)
+                if !success {
+                        return false, nil
+                }
 
-        return true
+                if !validateCNIConfigs(cniType, CNIConfigs, &rl.Results) {
+                        return false, nil
+                }
+
+                nadKubeObject, err := createNADKubeObject(kubeObject.GetName(), CNIConfigs, resourceName, nadDir)
+                if err != nil {
+                        rl.Results = append(rl.Results, fn.GeneralResult(fmt.Sprintf("failed to create NAD %v", err), fn.Error))
+
+                        return false, err
+                }
+
+		        if err := rl.UpsertObjectToItems(nadKubeObject, checkExistence, true); err != nil {
+		                return false, err
+		        }
+        }
+
+        rl.Results = append(rl.Results, fn.GeneralResult("Successfully created all NADs", fn.Info))
+
+	return true, nil
 }
 
 func main() {
-	runner := fn.WithContext(context.Background(), &ConfigureNad{})
-	if err := fn.AsMain(runner); err != nil {
+	if err := fn.AsMain(fn.ResourceListProcessorFunc(CreateNad)); err != nil {
 		os.Exit(1)
 	}
 }
+
+func loadConfigMapConfigs(kubeObject *fn.KubeObject, results *fn.Results) (bool, string, string, string) {
+        nadDir := filepath.Dir(kubeObject.PathAnnotation())
+
+        var ConfigMapData dataContainer
+
+        err := kubeObject.As(&ConfigMapData)
+        if err != nil {
+                *results = append(*results, fn.GeneralResult("Error loading configMap", fn.Error))
+                *results = append(*results, fn.ErrorResult(err))
+
+                return false, "", "", ""
+        }
+
+        cniData, ok := ConfigMapData.(map[string]interface{})["data"]
+        if !ok {
+                *results = append(*results, fn.GeneralResult("ConfigMap is missing the data", fn.Error))
+
+                return false, "", "", ""
+        }
+
+        cniType, ok := cniData.(map[string]interface{})["type"]
+        if !ok {
+                *results = append(*results, fn.GeneralResult("ConfigMap is missing the type", fn.Error))
+
+                return false, "", "", ""
+        }
+
+        jsonData, err := json.Marshal(cniData)
+        if err != nil {
+                *results = append(*results, fn.ErrorResult(err))
+
+                return false, "", "", ""
+        }
+
+        cniConfigs := string(jsonData)
+
+        return true, cniType.(string), cniConfigs, nadDir
+}
+
+func validateCNIConfigs(cniType string, cniConfigs string, results *fn.Results) bool {
+    sriovCNISchema, err := schemaValidators.GetSchema(cniType)
+    if err != nil {
+        *results = append(*results, fn.ErrorResult(err))
+
+        return false
+    }
+
+    configJSONLoader := gojsonschema.NewStringLoader(cniConfigs)
+
+    result, err := sriovCNISchema.Validate(configJSONLoader)
+    if err != nil {
+        *results = append(*results, fn.GeneralResult("Error while validating the CNI config", fn.Error))
+        *results = append(*results, fn.ErrorResult(err))
+
+        return false
+
+    } else if !result.Valid() {
+        *results = append(*results, fn.GeneralResult("Error in CNI config schema!", fn.Error))
+
+        for _, ResultErr := range result.Errors() {
+            *results = append(*results, fn.GeneralResult(ResultErr.String(), fn.Error))
+        }
+
+        return false
+    }
+
+    return true
+}
+
+func createNADKubeObject(nadName string, nadConfig string, resourceName string, nadDir string) (*fn.KubeObject, error) {
+        nadPath := filepath.Join(nadDir, nadName + ".yaml")
+
+	nadKubeobject := fn.NewEmptyKubeObject()
+
+        if err := nadKubeobject.SetAPIVersion("k8s.cni.cncf.io/v1"); err != nil {
+                return fn.NewEmptyKubeObject(), err
+        }
+
+        if err := nadKubeobject.SetKind("NetworkAttachmentDefinition"); err != nil {
+                return fn.NewEmptyKubeObject(), err
+        }
+
+        if err := nadKubeobject.SetName(nadName); err != nil {
+                return fn.NewEmptyKubeObject(), err
+        }
+
+        if err := nadKubeobject.SetNestedString(nadConfig, "spec", "config"); err != nil {
+                return fn.NewEmptyKubeObject(), err
+	}
+
+	if err := nadKubeobject.SetAnnotation("internal.config.kubernetes.io/path", nadPath); err != nil {
+		return fn.NewEmptyKubeObject(), err
+	}
+
+        if resourceName != "" {
+                if err := nadKubeobject.SetAnnotation("k8s.v1.cni.cncf.io/resourceName", resourceName); err != nil {
+                        return fn.NewEmptyKubeObject(), err
+                }
+        }
+
+        return nadKubeobject, nil
+}
+
+func (sv *schemaValidator) GetSchema(schemaName string) (*gojsonschema.Schema, error) {
+	s, ok := sv.schemas[schemaName]
+	if !ok {
+		return nil, fmt.Errorf("validation schema not found: %s", schemaName)
+	}
+	return s, nil
+}
+
+func InitSchemaValidator(schemaPath string) error {
+	sv := &schemaValidator{
+		schemas: make(map[string]*gojsonschema.Schema),
+	}
+
+	files, err := os.ReadDir(schemaPath)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		s, err := gojsonschema.NewSchema(gojsonschema.NewReferenceLoader(fmt.Sprintf("file://%s/%s", schemaPath, f.Name())))
+		if err != nil {
+		    return err
+		}
+
+		sv.schemas[strings.TrimSuffix(f.Name(), ".json")] = s
+	}
+
+	schemaValidators = sv
+
+	return nil
+}
+
+func scriptDir() string {
+	path, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Dir(path)
+}
+
+func checkExistence(obj, another *fn.KubeObject) bool {
+    return obj.GetKind() == another.GetKind() && obj.GetName() == another.GetName()
+}
+

--- a/sriovpod/Kptfile
+++ b/sriovpod/Kptfile
@@ -10,10 +10,10 @@ pipeline:
   mutators:
     - image: abdysn/configure-nad-krm:latest
       selectors:
-        - name: "sriov-net-a"
+        - kind: ConfigMap
+          name: "sriov-net-a"
       configMap:
         resourceName: "intel.com/sriov"
-        config: '{ "type": "sriov", "vlan": 1000, "ipam": { "type": "host-local", "subnet": "10.56.217.0/24", "rangeStart": "10.56.217.171", "rangeEnd": "10.56.217.181", "routes": [{ "dst": "0.0.0.0/0" }], "gateway": "10.56.217.1" } }'
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4
       selectors:
         - kind: Pod

--- a/sriovpod/resources/config-maps/sriov-cm.yaml
+++ b/sriovpod/resources/config-maps/sriov-cm.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriov-net-a
+  annotations:
+    configure-nad: ""
+data:
+  type: "sriov"
+  vlan: 1000
+  ipam:
+    type: "host-local"
+    subnet: "10.56.217.0/24"
+    rangeStart: "10.56.217.171"
+    rangeEnd: "10.56.217.181"
+    gateway: "10.56.217.1"
+    routes:
+      - dst: "0.0.0.0/0"

--- a/sriovpod/resources/nads/sriov-net.yaml
+++ b/sriovpod/resources/nads/sriov-net.yaml
@@ -1,5 +1,0 @@
-apiVersion: "k8s.cni.cncf.io/v1"
-kind: NetworkAttachmentDefinition
-metadata:
-  name: sriov-net-a
-


### PR DESCRIPTION
To be more practical, and ease the user experience changed the way to configure the nad, by switching from configuring nad using kpt kubeconfig, to using configmaps to specify the nad configurations.

Done that by changing the tartget resource from being nads, to be configmaps with a specific annotation. the scripts would read the configmap, and create the nad from the configmap data.